### PR TITLE
[4.28] Add setup-gradle with cache-disabled and setup-java caching

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,11 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '11'
+          cache: gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+        with:
+          cache-disabled: true
       - name: Check
         run: ./gradlew check
       - name: Publish to Maven Central


### PR DESCRIPTION
## Summary

- Add `setup-gradle` with `cache-disabled: true` to all workflows running Gradle
- Add `cache: gradle` to `setup-java` where missing (MIT-licensed, writes on all branches)

Tracked by [INT-247](https://linear.app/hivemq/issue/INT-247)